### PR TITLE
Fix implementation with latest composer LibraryInstaller

### DIFF
--- a/src/CustomInstaller.php
+++ b/src/CustomInstaller.php
@@ -23,21 +23,16 @@ class CustomInstaller extends LibraryInstaller
      */
     public function getInstallPath(PackageInterface $package)
     {
-        return parent::getInstallPath($package);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getPackageBasePath(PackageInterface $package)
-    {
         $configuration = $this->getPluginConfiguration();
         $pattern = $configuration->getPattern($package);
         if ($pattern) {
-            return $this->buildPath($pattern, $this->getPackageReplacementTokens($package));
+            $basePath = $this->buildPath($pattern, $this->getPackageReplacementTokens($package));
+            $targetDir = $package->getTargetDir();
+            return $basePath . ($targetDir ? '/'.$targetDir : '');
         } else {
-            return parent::getPackageBasePath($package);
+            return parent::getInstallPath($package);
         }
+
     }
 
     /**


### PR DESCRIPTION
With https://github.com/composer/composer/commit/d98b134dc3ef7d5bd4b6e37c9621a811f8f1599d the LibraryInstaller changed, so overriding `getPackageBasePath()` does not work anymore.

We now need to directly overwrite getInstallPath (which is good as only this is part of the `InstallerInterface` :sweat_smile: ).